### PR TITLE
fix(ci): ignore uuid in mobile to silence stuck security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,19 @@ updates:
     commit-message:
       prefix: "ci"
 
+  # npm ecosystem blocks below exist only to host `ignore` rules for
+  # security updates GitHub auto-runs regardless of dependabot.yml.
+  # open-pull-requests-limit: 0 keeps regular version bumps OFF so
+  # this isn't a flood; security updates still flow for everything
+  # except the listed packages.
+  - package-ecosystem: "npm"
+    directory: "/apps/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    # uuid <14 security advisory: locked to v7 by RN/Expo transitive
+    # peer-deps; no patched version reachable without breaking the RN
+    # ecosystem. Re-enable when upstream RN/Expo bumps past 14.0.0.
+    ignore:
+      - dependency-name: "uuid"
+


### PR DESCRIPTION
## Why
GitHub auto-runs a Dependabot security update for `uuid <14` daily. uuid is locked to v7 by Expo/RN transitive peer-deps, so Dependabot reports `security_update_not_possible` with `fix_available: false`. The **Dependabot Updates** workflow has been failing every run for weeks.

## What
Add a minimal npm ecosystem block for `/apps/mobile` with:
- `open-pull-requests-limit: 0` — keeps regular version bumps **off** (this directory was never configured before)
- `ignore: - dependency-name: "uuid"` — suppresses the failing security update path

Other security advisories on `/apps/mobile` will still create PRs; only `uuid` is suppressed until upstream RN/Expo bumps past 14.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)